### PR TITLE
Rematch pattern head: refinement through abstract types

### DIFF
--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -206,6 +206,8 @@ module Simple : sig
     clause list
 
   val omega : pattern
+
+  val expand_record : pattern -> pattern
 end = struct
   type nonrec pattern = pattern
 
@@ -244,6 +246,12 @@ end = struct
          ((alpha_pat env p, patl), mk_action ~vars:(List.map snd env)) :: rem
     in
     explode (Half_simple.to_pattern p) [] rem
+
+  let expand_record sp =
+    match sp.pat_desc with
+      | Tpat_record (l, _) ->
+         {sp with pat_desc = Tpat_record (all_record_args l, Closed)}
+      | _ -> sp
 
   let try_no_or hsp =
     let p = Half_simple.to_pattern hsp in
@@ -365,6 +373,7 @@ end = struct
   let combine ctx = List.map Row.combine ctx
 
   let ctx_matcher p q rem =
+    ignore Simple.expand_record;
     let rec expand_record p =
       match p.pat_desc with
         | Tpat_record (l, _) ->

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -86,6 +86,7 @@ module Pattern_head : sig
 
   val omega : t
 
+  val expand_record : t -> t
 end = struct
   type desc =
     | Any
@@ -246,6 +247,12 @@ end = struct
     ; env = Env.empty
     ; attributes = []
     }
+
+  let expand_record t =
+    match t.desc with
+      | Record ({ lbl_all; _ } :: _ ) ->
+         { t with desc = Record (Array.to_list lbl_all) }
+      | _ -> t
 end
 
 (*

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -72,6 +72,7 @@ module Pattern_head : sig
 
   val omega : t
 
+  val expand_record : t -> t
 end
 
 val normalize_pat : pattern -> pattern


### PR DESCRIPTION
This is the "approach I'm not so fond of" I mentioned in https://github.com/trefis/ocaml/pull/7#issuecomment-507150868 . `ctx_matcher` and `specialize_context` now use finer-grained types inside, but `specialize_context` is still taking a general pattern to avoid having to fix just every function in the rest of the code.

I now plan to experiment with the polymorphic-variant approach and compare.

This PR is on top of #7. (Maybe it would be easier if you included #7 as some branch in your repo, to base further PRs on top of it?)