### PR TITLE
Rematch pattern head: using polymorphic variants (WIP)

### DIFF
--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -84,7 +84,7 @@ module Non_empty_clause = struct
     | [], _ -> assert false
     | pat :: patl, act -> ((pat, patl), act)
 
-  let map f ((p, patl), act) = ((f p, patl), act)
+  let map_head f ((p, patl), act) = ((f p, patl), act)
 end
 
 type simple_view = [
@@ -98,18 +98,15 @@ type simple_view = [
   | `Lazy of pattern
   | `Exception of pattern
 ]
-type var_view = [ `Var of Ident.t * string loc ]
-type alias_view = [ `Alias of pattern * Ident.t * string loc ]
-type or_view = [ `Or of pattern * pattern * row_desc option ]
 
 type half_simple_view = [
   | simple_view
-  | or_view
+  | `Or of pattern * pattern * row_desc option
 ]
 type general_view = [
   | half_simple_view
-  | var_view
-  | alias_view
+  | `Var of Ident.t * string loc
+  | `Alias of pattern * Ident.t * string loc
 ]
 
 module General : sig
@@ -901,7 +898,7 @@ let safe_before ((p, ps), act_p) l =
 let half_simplify_nonempty
       args (cls : Typedtree.pattern Non_empty_clause.t) : Half_simple.clause =
   cls
-  |> Non_empty_clause.map General.view
+  |> Non_empty_clause.map_head General.view
   |> Half_simple.of_clause ~args
 
 let half_simplify_clause args (cls : Typedtree.pattern list clause) =

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1412,14 +1412,8 @@ and precompile_or argo (cls : Simple.clause list) ors args def k =
   let cases, handlers = do_cases ors in
   let matrix =
     as_matrix
-      (List.map
-         (fun ((p, ps), act) -> (((p :> General.pattern), ps), act))
-         cls
-      @ List.map
-          (fun ((p, ps), act) ->
-            (((p :> General.pattern), ps), act))
-          ors
-      )
+      ((cls : Simple.clause list :> General.clause list)
+       @ (ors : Half_simple.clause list :> General.clause list))
   and body = { cases = cls @ cases; args; default = def } in
   ( { me = PmOr { body; handlers; or_matrix = matrix };
       matrix;

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -450,7 +450,7 @@ end = struct
     let qh, args = Pattern_head.deconstruct (expand_record q) in
     let yes () = (p, args @ rem) in
     let no () = raise NoMatch in
-    let yesif b = if not b then raise NoMatch else (p, args @ rem) in
+    let yesif b = if b then yes () else no () in
     match Pattern_head.desc ph, Pattern_head.desc qh with
       | Any, _ -> fatal_error "Matching.Context.matcher"
       | _, Any -> (p, omegas @ rem)

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -78,17 +78,159 @@ let all_record_args lbls =
 type 'a clause = 'a * lambda
 
 module Non_empty_clause = struct
-  type 'a t = ('a * pattern list) clause
+  type 'a t = ('a * Typedtree.pattern list) clause
 
   let of_initial = function
     | [], _ -> assert false
     | pat :: patl, act -> ((pat, patl), act)
+
+  let map f ((p, patl), act) = ((f p, patl), act)
 end
 
-module General = struct
-  type nonrec pattern = pattern
+type simple_view = [
+  | `Any
+  | `Constant of constant
+  | `Tuple of pattern list
+  | `Construct of Longident.t loc * constructor_description * pattern list
+  | `Variant of label * pattern option * row_desc ref
+  | `Record of (Longident.t loc * label_description * pattern) list * closed_flag
+  | `Array of pattern list
+  | `Lazy of pattern
+  | `Exception of pattern
+]
+type var_view = [ `Var of Ident.t * string loc ]
+type alias_view = [ `Alias of pattern * Ident.t * string loc ]
+type or_view = [ `Or of pattern * pattern * row_desc option ]
+
+type half_simple_view = [
+  | simple_view
+  | or_view
+]
+type general_view = [
+  | half_simple_view
+  | var_view
+  | alias_view
+]
+
+type 'view pattern_ = pattern_data * 'view
+and pattern_data = {
+  loc: Location.t;
+  extra : (pat_extra * Location.t * attributes) list;
+  type_: type_expr;
+  env: Env.t;
+  attributes: attributes;
+}
+
+module General : sig
+  type pattern = general_view pattern_
   type clause = pattern Non_empty_clause.t
+
+  val view : Typedtree.pattern -> pattern
+  val erase : [< general_view ] pattern_ -> Typedtree.pattern
+
+  val alpha : (Ident.t * Ident.t) list ->
+              ([< general_view ] as 'view) pattern_ -> 'view pattern_
+end = struct
+  type pattern = general_view pattern_
+  type clause = pattern Non_empty_clause.t
+
+  let view p : pattern =
+    let data = {
+        loc = p.pat_loc;
+        extra = p.pat_extra;
+        type_ = p.pat_type;
+        env = p.pat_env;
+        attributes = p.pat_attributes;
+      } in
+    let view = match p.pat_desc with
+        | Tpat_any ->
+           `Any
+        | Tpat_var (id, str) ->
+           `Var (id, str)
+        | Tpat_alias (p, id, str) ->
+           `Alias (p, id, str)
+        | Tpat_constant cst ->
+           `Constant cst
+        | Tpat_tuple ps ->
+           `Tuple ps
+        | Tpat_construct (cstr, cstr_descr, args) ->
+
+           `Construct (cstr, cstr_descr, args)
+        | Tpat_variant (cstr, arg, row_desc) ->
+
+           `Variant (cstr, arg, row_desc)
+        | Tpat_record (fields, closed) ->
+           `Record (fields, closed)
+        | Tpat_array ps -> `Array ps
+        | Tpat_or (p, q, row_desc) -> `Or (p, q, row_desc)
+        | Tpat_lazy p -> `Lazy p
+        | Tpat_exception p -> `Exception p
+    in
+    (data, view)
+
+  let erase (data, view) =
+    let desc = match view with
+        | `Any -> Tpat_any
+        | `Var (id, str) -> Tpat_var (id, str)
+        | `Alias (p, id, str) -> Tpat_alias (p, id, str)
+        | `Constant cst -> Tpat_constant cst
+        | `Tuple ps -> Tpat_tuple ps
+        | `Construct (cstr, cst_descr, args) ->
+           Tpat_construct (cstr, cst_descr, args)
+        | `Variant (cstr, arg, row_desc) ->
+           Tpat_variant (cstr, arg, row_desc)
+        | `Record (fields, closed) ->
+           Tpat_record (fields, closed)
+        | `Array ps -> Tpat_array ps
+        | `Or (p, q, row_desc) -> Tpat_or (p, q, row_desc)
+        | `Lazy p -> Tpat_lazy p
+        | `Exception p -> Tpat_exception p
+    in
+    {
+      pat_desc = desc;
+      pat_loc = data.loc;
+      pat_extra = data.extra;
+      pat_type = data.type_;
+      pat_env = data.env;
+      pat_attributes = data.attributes;
+    }
+
+  let alpha
+    : 'view . _ -> ([< general_view ] as 'view) pattern_ -> 'view pattern_
+    = fun env (data, view) ->
+    let alpha_var env id = List.assoc id env in
+    let alpha_pat = Typedtree.alpha_pat in
+    let view = match view with
+    | `Any -> `Any
+    | `Var (id, s) ->
+       begin match alpha_var env id with
+         | exception Not_found -> assert false
+         | id -> `Var (id, s)
+       end
+    | `Alias (p, id, s) ->
+       begin match alpha_var env id with
+         | exception Not_found -> assert false
+         | id -> `Alias (alpha_pat env p, id, s)
+       end
+    | `Constant cst -> `Constant cst
+    | `Tuple ps -> `Tuple (List.map (alpha_pat env) ps)
+    | `Construct (cstr, cst_descr, args) ->
+      `Construct (cstr, cst_descr, List.map (alpha_pat env) args)
+    | `Variant (cstr, argo, row_desc) ->
+      `Variant (cstr, Option.map (alpha_pat env) argo, row_desc)
+    | `Record (fields, closed) ->
+       let alpha_field env (lid, l, p) = (lid, l, alpha_pat env p) in
+      `Record (List.map (alpha_field env) fields, closed)
+    | `Array ps -> `Array (List.map (alpha_pat env) ps)
+    | `Or (p, q, row_desc) -> `Or (alpha_pat env p, alpha_pat env q, row_desc)
+    | `Lazy p -> `Lazy (alpha_pat env p)
+    | `Exception p -> `Exception (alpha_pat env p)
+    in (data, Obj.magic (* FIXME *) view)
 end
+
+let omega_ : [> `Any ] pattern_ =
+  let data = fst (General.view Parmatch.omega) in
+  (data, `Any)
 
 module Half_simple : sig
   (** Half-simplified patterns are patterns where:
@@ -111,18 +253,14 @@ module Half_simple : sig
       In particular, or-patterns may still occur in the leading column,
       so this is only a "half-simplification". *)
 
-  type pattern
-
-  val to_pattern : pattern -> General.pattern
+  type pattern = half_simple_view pattern_
 
   type clause = pattern Non_empty_clause.t
 
   val of_clause : args:(lambda * 'a) list -> General.clause -> clause
 end = struct
-  type nonrec pattern = pattern
+  type pattern = half_simple_view pattern_
   type clause = pattern Non_empty_clause.t
-
-  let to_pattern p = p
 
   let rec simpl_orpat p =
     match p.pat_desc with
@@ -143,41 +281,35 @@ end = struct
     | _ -> p
 
   let of_clause ~args cl =
-    let rec aux ((pat, patl), action) =
-      match pat.pat_desc with
-      | Tpat_any -> ((pat, patl), action)
-      | Tpat_var (id, s) ->
-          let p = { pat with pat_desc = Tpat_alias (omega, id, s) } in
-          aux ((p, patl), action)
-      | Tpat_alias (p, id, _) ->
+    let rec aux ((((data, view), patl), action) : General.clause) : clause =
+      match view with
+      | `Any -> (((data, `Any), patl), action)
+      | `Var (id, s) ->
+          aux (((data, `Alias (omega, id, s)), patl), action)
+      | `Alias (p, id, _) ->
           let arg =
             match args with
             | [] -> assert false
             | (arg, _) :: _ -> arg
           in
-          let k = Typeopt.value_kind pat.pat_env pat.pat_type in
-          aux ((p, patl), bind_with_value_kind Alias (id, k) arg action)
-      | Tpat_record ([], _) -> ((omega, patl), action)
-      | Tpat_record (lbls, closed) ->
-          let all_lbls = all_record_args lbls in
-          let full_pat =
-            { pat with pat_desc = Tpat_record (all_lbls, closed) }
-          in
-          ((full_pat, patl), action)
-      | Tpat_or _ -> (
-          let pat_simple = simpl_orpat pat in
-          match pat_simple.pat_desc with
-          | Tpat_or _ -> ((pat_simple, patl), action)
-          | _ -> aux ((pat_simple, patl), action)
+          let k = Typeopt.value_kind data.env data.type_ in
+          aux ((General.view p, patl),
+               bind_with_value_kind Alias (id, k) arg action)
+      | `Record ([], _) as view -> (((data, view), patl), action)
+      | `Record (lbls, closed) ->
+          let full_pat = `Record (all_record_args lbls, closed) in
+          (((data, full_pat), patl), action)
+      | `Or _ as orpat -> (
+        let (data, view) =
+          General.view (simpl_orpat (General.erase (data, orpat))) in
+        match view with
+          | `Or _ as view -> (((data, view), patl), action)
+          | _ -> aux (((data, view), patl), action)
         )
-      | Tpat_constant _
-      | Tpat_tuple _
-      | Tpat_construct _
-      | Tpat_variant _
-      | Tpat_array _
-      | Tpat_lazy _
-      | Tpat_exception _ ->
-          ((pat, patl), action)
+      | (`Constant _ | `Tuple _ | `Construct _ | `Variant _
+      |  `Array _ | `Lazy _ | `Exception _) as view ->
+         (((data, view), patl), action)
+
     in
     aux cl
 end
@@ -185,37 +317,24 @@ end
 exception Cannot_flatten
 
 module Simple : sig
-  type pattern
-  (** A fully simplified pattern: or-patterns have been exploded, and the
-      remaining aliases have been removed and replaced by bindings in actions *)
-
+  type pattern = simple_view pattern_
   type clause = pattern Non_empty_clause.t
-
-  val try_no_or : Half_simple.pattern -> pattern option
-
-  val to_pattern : pattern -> General.pattern
 
   val head : pattern -> Pattern_head.t
 
   val explode_or_pat :
-    Half_simple.pattern * General.pattern list ->
+    Half_simple.pattern * Typedtree.pattern list ->
     arg:Ident.t option ->
     mk_action:(vars:Ident.t list -> lambda) ->
     vars:Ident.t list ->
     clause list ->
     clause list
-
-  val omega : pattern
 end = struct
-  type nonrec pattern = pattern
-
-  let omega = omega
-
+  type pattern = simple_view pattern_
   type clause = pattern Non_empty_clause.t
 
-  let to_pattern p = p
-
-  let head p = fst (Pattern_head.deconstruct p)
+  let head p =
+    fst (Pattern_head.deconstruct (General.erase (p :> General.pattern)))
 
   let mk_alpha_env arg aliases ids =
     List.map
@@ -229,27 +348,24 @@ end = struct
             Ident.create_local (Ident.name id) ))
       ids
 
-  let explode_or_pat (p, patl) ~arg ~mk_action ~vars rem =
-    let rec explode p aliases rem =
-      match p.pat_desc with
-      | Tpat_or (p1, p2, _) ->
-         explode p1 aliases (explode p2 aliases rem)
-      | Tpat_alias (p, id, _) ->
-         explode p (id :: aliases) rem
-      | Tpat_var (x, _) ->
-         let env = mk_alpha_env arg (x :: aliases) vars in
-         ((omega, patl), mk_action ~vars:(List.map snd env)) :: rem
-      | _ ->
+  let explode_or_pat ((p : Half_simple.pattern), patl) ~arg ~mk_action ~vars
+        (rem : clause list) : clause list =
+    let rec explode (data, (view : general_view)) aliases rem =
+      let split_explode p aliases rem =
+        explode (General.view p) aliases rem in
+      match view with
+      | `Or (p1, p2, _) ->
+         split_explode p1 aliases (split_explode p2 aliases rem)
+      | `Alias (p, id, _) ->
+         split_explode p (id :: aliases) rem
+      | `Var (id, str) ->
+         explode (data, `Alias (Parmatch.omega, id, str)) aliases rem
+      | #simple_view as view ->
          let env = mk_alpha_env arg aliases vars in
-         ((alpha_pat env p, patl), mk_action ~vars:(List.map snd env)) :: rem
+         ((General.alpha env (data, view), patl),
+          mk_action ~vars:(List.map snd env)) :: rem
     in
-    explode (Half_simple.to_pattern p) [] rem
-
-  let try_no_or hsp =
-    let p = Half_simple.to_pattern hsp in
-    match p.pat_desc with
-      | Tpat_or _ -> None
-      | _ -> Some p
+    explode (p : Half_simple.pattern :> General.pattern) [] rem
 end
 
 type initial_clause = pattern list clause
@@ -696,14 +812,14 @@ let pretty_hc_pm pm =
   pretty_cases
     (List.map
        (fun ((p, ps), act) ->
-         (Half_simple.to_pattern p :: ps, act))
+         (General.erase p :: ps, act))
        pm.cases);
   if pm.default <> [] then pretty_def pm.default
 
 let pretty_sc_pm pm =
   pretty_cases
     (List.map
-       (fun ((p, ps), act) -> (Simple.to_pattern p :: ps, act))
+       (fun ((p, ps), act) -> (General.erase p :: ps, act))
        pm.cases);
   if pm.default <> [] then pretty_def pm.default
 
@@ -807,7 +923,7 @@ let same_actions = function
             None
     )
 
-let safe_before to_pattern ((p, ps), act_p) l =
+let safe_before ((p, ps), act_p) l =
   (* Test for swapping two clauses *)
   let same_actions act1 act2 =
     match (make_key act1, make_key act2) with
@@ -819,13 +935,19 @@ let safe_before to_pattern ((p, ps), act_p) l =
   List.for_all
     (fun ((q, qs), act_q) ->
       same_actions act_p act_q
-      || not (may_compats (to_pattern p :: ps) (to_pattern q :: qs)))
+      || not (may_compats (General.erase p :: ps) (General.erase q :: qs)))
     l
 
-let half_simplify_clause args cls =
+let half_simplify_nonempty
+      args (cls : Typedtree.pattern Non_empty_clause.t) : Half_simple.clause =
+  cls
+  |> Non_empty_clause.map General.view
+  |> Half_simple.of_clause ~args
+
+let half_simplify_clause args (cls : Typedtree.pattern list clause) =
   cls
   |> Non_empty_clause.of_initial
-  |> Half_simple.of_clause ~args
+  |> half_simplify_nonempty args
 
 let half_simplify_cases args cls = List.map (half_simplify_clause args) cls
 
@@ -834,7 +956,7 @@ let half_simplify_cases args cls = List.map (half_simplify_clause args) cls
 
 let rec what_is_cases cases =
   match cases with
-  | [] -> Simple.omega
+  | [] -> omega_
   | ((p, _), _) :: rem -> (
       match Pattern_head.desc (Simple.head p) with
       | Any -> what_is_cases rem
@@ -966,11 +1088,11 @@ let is_or p =
 
 let equiv_pat p q = le_pat p q && le_pat q p
 
-let rec extract_equiv_head to_pattern p l =
+let rec extract_equiv_head p l =
   match l with
   | (((q, _), _) as cl) :: rem ->
-      if equiv_pat p (to_pattern q) then
-        let others, rem = extract_equiv_head to_pattern p rem in
+      if equiv_pat p (General.erase q) then
+        let others, rem = extract_equiv_head p rem in
         (cl :: others, rem)
       else
         ([], l)
@@ -999,10 +1121,10 @@ module Or_matrix = struct
   let safe_below (ps, act) qs =
     (not (is_guarded act)) && Parmatch.le_pats ps qs
 
-  let safe_below_or_matrix to_pattern l (q, qs) =
+  let safe_below_or_matrix l (q, qs) =
     List.for_all
       (fun ((p, ps), act_p) ->
-        let p = to_pattern p in
+        let p = General.erase p in
         match p.pat_desc with
         | Tpat_or _ -> disjoint p q || safe_below (ps, act_p) qs
         | _ -> true)
@@ -1017,14 +1139,14 @@ module Or_matrix = struct
   let insert_or_append (head, ps, act) rev_ors rev_no =
     let safe_to_insert rem (p, ps) seen =
       let _, not_e =
-        extract_equiv_head Half_simple.to_pattern p rem
+        extract_equiv_head p rem
       in
       (* check append condition for head of O *)
-      safe_below_or_matrix Half_simple.to_pattern not_e (p, ps)
+      safe_below_or_matrix not_e (p, ps)
       && (* check insert condition for tail of O *)
          List.for_all
            (fun ((q, _), _) ->
-             disjoint p (Half_simple.to_pattern q))
+             disjoint p (General.erase q))
            seen
     in
     let rec attempt seen = function
@@ -1032,8 +1154,8 @@ module Or_matrix = struct
          [seen] (but maybe not [rem] yet) *)
       | [] -> (((head, ps), act) :: rev_ors, rev_no)
       | (((q, qs), act_q) as cl) :: rem ->
-          let p = Half_simple.to_pattern head in
-          let q = Half_simple.to_pattern q in
+          let p = General.erase head in
+          let q = General.erase q in
           if (not (is_or q)) || disjoint p q then
             attempt (cl :: seen) rem
           else if
@@ -1057,8 +1179,8 @@ end
 
 (* Reconstruct default information from half_compiled  pm list *)
 
-let as_matrix pat_of_head cases =
-  get_mins le_pats (List.map (fun ((p, ps), _) -> pat_of_head p :: ps) cases)
+let as_matrix cases =
+  get_mins le_pats (List.map (fun ((p, ps), _) -> General.erase p :: ps) cases)
 
 (*
   Split a matching along the first column.
@@ -1109,12 +1231,12 @@ let rec split_or argo (cls : Half_simple.clause list) args def =
   let rec do_split (rev_before : Simple.clause list) rev_ors rev_no = function
     | [] ->
         cons_next (List.rev rev_before) (List.rev rev_ors) (List.rev rev_no)
-    | cl :: rem when not (safe_before Half_simple.to_pattern cl rev_no) ->
+    | cl :: rem when not (safe_before cl rev_no) ->
        do_split rev_before rev_ors (cl :: rev_no) rem
     | (((p, ps), act) as cl) :: rem -> (
-       match Simple.try_no_or p with
-         | Some sp when safe_before Half_simple.to_pattern cl rev_ors ->
-            do_split (((sp, ps), act) :: rev_before) rev_ors rev_no rem
+       match p with
+         | (data, (#simple_view as view)) when safe_before cl rev_ors ->
+            do_split ((((data, view), ps), act) :: rev_before) rev_ors rev_no rem
          | _ ->
             let rev_ors, rev_no =
               Or_matrix.insert_or_append (p, ps, act) rev_ors rev_no
@@ -1141,7 +1263,7 @@ let rec split_or argo (cls : Half_simple.clause list) args def =
 and split_no_or cls args def k =
   let rec collect_group can_group rev_yes rev_no = function
     | (((p, _), _) as cl) :: rem ->
-        if can_group p && safe_before Simple.to_pattern cl rev_no
+        if can_group p && safe_before cl rev_no
         then
           collect_group can_group (cl :: rev_yes) rev_no rem
         else
@@ -1151,7 +1273,7 @@ and split_no_or cls args def k =
         match no with
         | [] ->
             ( { me = Pm { cases = yes; args; default = def };
-                matrix = as_matrix Simple.to_pattern yes;
+                matrix = as_matrix yes;
                 top_default = def
               },
               k )
@@ -1167,7 +1289,7 @@ and split_no_or cls args def k =
                 let idef = next_raise_count () in
                 let def = cons_default matrix idef def in
                 ( { me = Pm { cases = yes; args; default = def };
-                    matrix = as_matrix Simple.to_pattern yes;
+                    matrix = as_matrix yes;
                     top_default = def
                   },
                   (idef, next) :: nexts )
@@ -1180,7 +1302,7 @@ and split_no_or cls args def k =
                last row is made of variables only *)
         collect_vars rev_yes (cl :: rev_no) []
     | (((p, _), _) as cl) :: rem ->
-        if group_var p && safe_before Simple.to_pattern cl rev_no
+        if group_var p && safe_before cl rev_no
         then
           collect_vars (cl :: rev_yes) rev_no rem
         else
@@ -1240,7 +1362,7 @@ and precompile_var args cls def k =
           | _ ->
               let rec rebuild_matrix pmh =
                 match pmh with
-                | Pm pm -> as_matrix Simple.to_pattern pm.cases
+                | Pm pm -> as_matrix pm.cases
                 | PmOr { or_matrix = m } -> m
                 | PmVar x -> add_omega_column (rebuild_matrix x.inside)
               in
@@ -1267,23 +1389,23 @@ and precompile_var args cls def k =
 
 and dont_precompile_var args cls def k =
   ( { me = Pm { cases = cls; args; default = def };
-      matrix = as_matrix Simple.to_pattern cls;
+      matrix = as_matrix cls;
       top_default = def
     },
     k )
 
-and precompile_or argo cls ors args def k =
+and precompile_or argo (cls : Simple.clause list) ors args def k =
   let rec do_cases = function
     | [] -> ([], [])
     | ((p, patl), action) :: rem -> (
-        match Simple.try_no_or p with
-        | Some sp ->
+        match p with
+        | (data, (#simple_view as view)) ->
             let new_ord, new_to_catch = do_cases rem in
-            (((sp, patl), action) :: new_ord, new_to_catch)
-        | None ->
-            let orp = Half_simple.to_pattern p in
+            ((((data, view), patl), action) :: new_ord, new_to_catch)
+        | (_data, `Or _) ->
+            let orp = General.erase p in
             let others, rem =
-              extract_equiv_head Half_simple.to_pattern orp rem
+              extract_equiv_head orp rem
             in
             let orpm =
               { cases =
@@ -1328,13 +1450,12 @@ and precompile_or argo cls ors args def k =
   let cases, handlers = do_cases ors in
   let matrix =
     as_matrix
-      (fun x -> x)
       (List.map
-         (fun ((p, ps), act) -> ((Simple.to_pattern p, ps), act))
+         (fun ((p, ps), act) -> (((p :> General.pattern), ps), act))
          cls
       @ List.map
           (fun ((p, ps), act) ->
-            ((Half_simple.to_pattern p, ps), act))
+            (((p :> General.pattern), ps), act))
           ors
       )
   and body = { cases = cls @ cases; args; default = def } in
@@ -1346,11 +1467,7 @@ and precompile_or argo cls ors args def k =
 
 let split_and_precompile_nonempty argo pm =
   let pm =
-    { pm with
-      cases =
-        List.map (Half_simple.of_clause ~args:pm.args) pm.cases
-    }
-  in
+    { pm with cases = List.map (half_simplify_nonempty pm.args) pm.cases } in
   let { me = next }, nexts = split_or argo pm.cases pm.args pm.default in
   if
     dbg
@@ -1433,7 +1550,7 @@ let add_in_div make_matching_fun eq_key key patl_action division =
 let divide make eq_key get_key get_args ctx
     (pm : Simple.clause pattern_matching) =
   let add ((p, patl), action) division =
-    let p = Simple.to_pattern p in
+    let p = General.erase p in
     add_in_div (make p pm.default ctx) eq_key (get_key p)
       (get_args p patl, action)
       division
@@ -1447,7 +1564,7 @@ let add_line patl_action pm =
 let divide_line make_ctx make get_args discr ctx
     (pm : Simple.clause pattern_matching) =
   let add ((p, patl), action) submatrix =
-    let p = Simple.to_pattern p in
+    let p = General.erase p in
     add_line (get_args p patl, action) submatrix
   in
   let pm = List.fold_right add pm.cases (make pm.default pm.args) in
@@ -1665,7 +1782,7 @@ let divide_variant row ctx { cases = cl; args; default = def } =
   let rec divide = function
     | [] -> { args; cells = [] }
     | ((p, patl), action) :: rem -> (
-        let p = Simple.to_pattern p in
+        let p = General.erase p in
         match p.pat_desc with
         | Tpat_variant (lab, pato, _) -> (
             let variants = divide rem in
@@ -3111,7 +3228,7 @@ and compile_simplified repr partial ctx
   | _ -> assert false
 
 and compile_half_compiled repr partial ctx
-    (m : pattern Non_empty_clause.t pattern_matching) =
+    (m : Typedtree.pattern Non_empty_clause.t pattern_matching) =
   match m with
   | { cases = []; args = [] } -> comp_exit ctx m
   | { args = ((Lvar v as arg), str) :: argl } ->
@@ -3166,7 +3283,7 @@ and do_compile_matching repr partial ctx pmh =
       in
       let pat = what_is_cases pm.cases in
       let ph = Simple.head pat in
-      let pat = Simple.to_pattern pat in
+      let pat = General.erase pat in
       match Pattern_head.desc ph with
       | Any ->
           compile_no_test divide_var Context.rshift repr partial ctx pm
@@ -3581,7 +3698,7 @@ let flatten_cases size cases =
   List.map
     (function
       | (p, []), action -> (
-          match flatten_pattern size (Simple.to_pattern p) with
+          match flatten_pattern size (General.erase p) with
           | p :: ps -> ((p, ps), action)
           | [] -> assert false
         )

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -26,8 +26,9 @@ type partial = Partial | Total
 type attribute = Parsetree.attribute
 type attributes = attribute list
 
-type pattern =
-  { pat_desc: pattern_desc;
+type pattern = pattern_desc pattern_
+and 'a pattern_ =
+  { pat_desc: 'a;
     pat_loc: Location.t;
     pat_extra : (pat_extra * Location.t * attribute list) list;
     pat_type: type_expr;

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -35,8 +35,9 @@ type attributes = attribute list
 
 (** {1 Core language} *)
 
-type pattern =
-  { pat_desc: pattern_desc;
+type pattern = pattern_desc pattern_
+and 'a pattern_ =
+  { pat_desc: 'a;
     pat_loc: Location.t;
     pat_extra : (pat_extra * Location.t * attributes) list;
     pat_type: type_expr;


### PR DESCRIPTION
This is a WIP alternative to #8, using polymorphic variants instead of abstract types to classify "simple", "half-simple" and general patterns.

It would say that this version requires a bit more boilerplate than the previous one, but that the code in the tricky parts (where invariants are used/enforced/maintained) is (mildly) nicer. Compare for example the definition of `do_split`, or remark that the spurious `to_pattern` arguments are gone.