### PR TITLE
merge split_naive and split_constr: a simpler recursion scheme

### DIFF
--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1204,13 +1204,10 @@ and split_no_or cls args def k =
     collect discr [] [] cls
   and collect group_discr rev_yes rev_no = function
     | ([], _) :: _ -> assert false
-    (*
-         (* TODO: check if this would works in this setup *)
     | [ ((ps, _) as cl) ] when List.for_all group_var ps && rev_yes <> [] ->
         (* This enables an extra division in some frequent cases:
                last row is made of variables only *)
-        collect rev_yes (cl :: rev_no) []
-      *)
+        collect group_discr rev_yes (cl :: rev_no) []
     | ((p :: _, _) as cl) :: rem ->
         if can_group group_discr p && safe_before cl rev_no then
           collect group_discr (cl :: rev_yes) rev_no rem

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -994,7 +994,7 @@ and group_lazy = function
   | { pat_desc = Tpat_lazy _ } -> true
   | _ -> false
 
-let get_group p =
+let can_group p =
   match p.pat_desc with
   | Tpat_any -> group_var
   | Tpat_constant (Const_int _) -> group_const_int
@@ -1017,7 +1017,7 @@ let get_group p =
   | Tpat_array _ -> group_array
   | Tpat_variant (_, _, _) -> group_variant
   | Tpat_lazy _ -> group_lazy
-  | _ -> fatal_error "Matching.get_group"
+  | _ -> fatal_error "Matching.can_group"
 
 let is_or p =
   match p.pat_desc with
@@ -1201,14 +1201,14 @@ and split_no_or cls args def k =
     if group_var discr then
       collect_vars [] [] cls
     else
-      collect_group (get_group discr) [] [] cls
-  and collect_group can_group rev_yes rev_no = function
+      collect_group discr [] [] cls
+  and collect_group group_discr rev_yes rev_no = function
     | ([], _) :: _ -> assert false
     | ((p :: _, _) as cl) :: rem ->
-        if can_group p && safe_before cl rev_no then
-          collect_group can_group (cl :: rev_yes) rev_no rem
+        if can_group group_discr p && safe_before cl rev_no then
+          collect_group group_discr (cl :: rev_yes) rev_no rem
         else
-          collect_group can_group rev_yes (cl :: rev_no) rem
+          collect_group group_discr rev_yes (cl :: rev_no) rem
     | [] ->
         let yes = List.rev rev_yes and no = List.rev rev_no in
         insert_split precompile_normal yes no def k

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -965,6 +965,11 @@ and group_constructor = function
   | { pat_desc = Tpat_construct (_, _, _) } -> true
   | _ -> false
 
+and group_same_constructor tag = function
+  | { pat_desc = Tpat_construct (_, cstr, _) } ->
+      Types.equal_tag tag cstr.cstr_tag
+  | _ -> false
+
 and group_variant = function
   | { pat_desc = Tpat_variant (_, _, _) } -> true
   | _ -> false
@@ -999,6 +1004,13 @@ let get_group p =
   | Tpat_constant (Const_int32 _) -> group_const_int32
   | Tpat_constant (Const_int64 _) -> group_const_int64
   | Tpat_constant (Const_nativeint _) -> group_const_nativeint
+  | Tpat_construct (_, { cstr_tag = Cstr_extension _ as t }, _) ->
+      (* Extension constructors with distinct names may be equal thanks to
+         constructor rebinding. So we need to produce a specialized
+         submatrix for each syntactically-distinct constructor (with a threading
+         of exits such that each submatrix falls back to the
+         potentially-compatible submatrices below it).  *)
+      group_same_constructor t
   | Tpat_construct _ -> group_constructor
   | Tpat_tuple _ -> group_tuple
   | Tpat_record _ -> group_record
@@ -1178,160 +1190,76 @@ let rec split_or argo cls args def =
           (Default_environment.cons matrix idef def, (idef, next) :: nexts)
     in
     match yesor with
-    | [] -> split_constr yes args def nexts
+    | [] -> split_no_or yes args def nexts
     | _ -> precompile_or argo yes yesor args def nexts
   in
   do_split [] [] [] cls
 
-(* Ultra-naive splitting, close to semantics, used for extension,
-   as potential rebind prevents any kind of optimisation
-
-   Indeed, extension constructors with distinct names may be equal thanks to
-   constructor rebinding. This is compiled by having a specialized
-   submatrix for each syntactically-distinct constructor, with a threading
-   of exits such that each submatrix falls back to the potentially-compatible
-   submatrices below it.
-*)
-and split_naive cls args def k =
-  let rec split_exc cstr0 rev_yes = function
-    | [] ->
-        let yes = List.rev rev_yes in
-        ( { me = Pm { cases = yes; args; default = def };
-            matrix = as_matrix yes;
-            top_default = def
-          },
-          k )
+and split_no_or cls args def k =
+  let rec collect_group can_group rev_yes rev_no = function
+    | ([], _) :: _ -> assert false
     | ((p :: _, _) as cl) :: rem ->
-        if group_constructor p then
-          let cstr = pat_as_constr p in
-          if cstr = cstr0 then
-            split_exc cstr0 (cl :: rev_yes) rem
-          else
-            let yes = List.rev rev_yes in
-            let { me = next; matrix; top_default = def }, nexts =
-              split_exc cstr [ cl ] rem
-            in
-            let idef = next_raise_count () in
-            let def = Default_environment.cons matrix idef def in
+        if can_group p && safe_before cl rev_no then
+          collect_group can_group (cl :: rev_yes) rev_no rem
+        else
+          collect_group can_group rev_yes (cl :: rev_no) rem
+    | [] -> (
+        let yes = List.rev rev_yes and no = List.rev rev_no in
+        match no with
+        | [] ->
             ( { me = Pm { cases = yes; args; default = def };
                 matrix = as_matrix yes;
                 top_default = def
               },
-              (idef, next) :: nexts )
-        else
-          let yes = List.rev rev_yes in
-          let { me = next; matrix; top_default = def }, nexts =
-            split_noexc [ cl ] rem
-          in
-          let idef = next_raise_count () in
-          let def = Default_environment.cons matrix idef def in
-          ( { me = Pm { cases = yes; args; default = def };
-              matrix = as_matrix yes;
-              top_default = def
-            },
-            (idef, next) :: nexts )
-    | _ -> assert false
-  and split_noexc rev_yes = function
-    | ([], _) :: _ -> assert false
-    | [] -> precompile_var args (List.rev rev_yes) def k
-    | ((p :: _, _) as cl) :: rem ->
-        if not (group_constructor p) then
-          split_noexc (cl :: rev_yes) rem
-        else
-          let yes = List.rev rev_yes in
-          let { me = next; matrix; top_default = def }, nexts =
-            split_exc (pat_as_constr p) [ cl ] rem
-          in
-          let idef = next_raise_count () in
-          precompile_var args yes
-            (Default_environment.cons matrix idef def)
-            ((idef, next) :: nexts)
-  in
-  match cls with
-  | [] -> assert false
-  | ((p :: _, _) as cl) :: rem ->
-      if group_constructor p then
-        split_exc (pat_as_constr p) [ cl ] rem
-      else
-        split_noexc [ cl ] rem
-  | _ -> assert false
-
-and split_constr cls args def k =
-  let ex_pat = what_is_cases cls in
-  match ex_pat.pat_desc with
-  | Tpat_any -> precompile_var args cls def k
-  | Tpat_construct (_, { cstr_tag = Cstr_extension _ }, _) ->
-      split_naive cls args def k
-  | _ -> (
-      let group = get_group ex_pat in
-      let rec split_ex rev_yes rev_no = function
-        | ([], _) :: _ -> assert false
-        | ((p :: _, _) as cl) :: rem ->
-            if group p && safe_before cl rev_no then
-              split_ex (cl :: rev_yes) rev_no rem
-            else
-              split_ex rev_yes (cl :: rev_no) rem
-        | [] -> (
-            let yes = List.rev rev_yes and no = List.rev rev_no in
-            match no with
+              k )
+        | cl :: rem -> (
+            match yes with
             | [] ->
+                (* Could not succeeed in raising up a constr matching up *)
+                collect_vars [ cl ] [] rem
+            | _ ->
+                let { me = next; matrix; top_default = def }, nexts =
+                  split no
+                in
+                let idef = next_raise_count () in
+                let def = Default_environment.cons matrix idef def in
                 ( { me = Pm { cases = yes; args; default = def };
                     matrix = as_matrix yes;
                     top_default = def
                   },
-                  k )
-            | cl :: rem -> (
-                match yes with
-                | [] ->
-                    (* Could not succeeed in raising up a constr matching up *)
-                    split_noex [ cl ] [] rem
-                | _ ->
-                    let { me = next; matrix; top_default = def }, nexts =
-                      split_noex [ cl ] [] rem
-                    in
-                    let idef = next_raise_count () in
-                    let def = Default_environment.cons matrix idef def in
-                    ( { me = Pm { cases = yes; args; default = def };
-                        matrix = as_matrix yes;
-                        top_default = def
-                      },
-                      (idef, next) :: nexts )
-              )
+                  (idef, next) :: nexts )
           )
-      and split_noex rev_yes rev_no = function
-        | ([], _) :: _ -> assert false
-        | [ ((ps, _) as cl) ] when List.for_all group_var ps && rev_yes <> []
-          ->
-            (* This enables an extra division in some frequent cases:
+      )
+  and collect_vars rev_yes rev_no = function
+    | ([], _) :: _ -> assert false
+    | [ ((ps, _) as cl) ] when List.for_all group_var ps && rev_yes <> [] ->
+        (* This enables an extra division in some frequent cases:
                last row is made of variables only *)
-            split_noex rev_yes (cl :: rev_no) []
-        | ((p :: _, _) as cl) :: rem ->
-            if (not (group p)) && safe_before cl rev_no then
-              split_noex (cl :: rev_yes) rev_no rem
-            else
-              split_noex rev_yes (cl :: rev_no) rem
-        | [] -> (
-            let yes = List.rev rev_yes and no = List.rev rev_no in
-            match no with
-            | [] -> precompile_var args yes def k
-            | cl :: rem ->
-                let { me = next; matrix; top_default = def }, nexts =
-                  split_ex [ cl ] [] rem
-                in
-                let idef = next_raise_count () in
-                precompile_var args yes
-                  (Default_environment.cons matrix idef def)
-                  ((idef, next) :: nexts)
-          )
-      in
-      match cls with
-      | ((p :: _, _) as cl) :: rem ->
-          if group p then
-            split_ex [ cl ] [] rem
-          else
-            split_noex [ cl ] [] rem
-      | _ -> assert false
-    )
+        collect_vars rev_yes (cl :: rev_no) []
+    | ((p :: _, _) as cl) :: rem ->
+        if group_var p && safe_before cl rev_no then
+          collect_vars (cl :: rev_yes) rev_no rem
+        else
+          collect_vars rev_yes (cl :: rev_no) rem
+    | [] -> (
+        let yes = List.rev rev_yes and no = List.rev rev_no in
+        match no with
+        | [] -> precompile_var args yes def k
+        | _ ->
+            let { me = next; matrix; top_default = def }, nexts = split no in
+            let idef = next_raise_count () in
+            precompile_var args yes
+              (Default_environment.cons matrix idef def)
+              ((idef, next) :: nexts)
+      )
+  and split cls =
+    let discr = what_is_cases cls in
+    if group_var discr then
+      collect_vars [] [] cls
+    else
+      collect_group (get_group discr) [] [] cls
+  in
+  split cls
 
 and precompile_var args cls def k =
   (* Strategy: pop the first column,

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1209,17 +1209,9 @@ and split_no_or cls args def k =
           collect_group can_group (cl :: rev_yes) rev_no rem
         else
           collect_group can_group rev_yes (cl :: rev_no) rem
-    | [] -> (
+    | [] ->
         let yes = List.rev rev_yes and no = List.rev rev_no in
-        match no with
-        | [] -> precompile_normal args yes def k
-        | _ ->
-            let { me = next; matrix; top_default = def }, nexts = split no in
-            let idef = next_raise_count () in
-            precompile_normal args yes
-              (Default_environment.cons matrix idef def)
-              ((idef, next) :: nexts)
-      )
+        insert_split precompile_normal yes no def k
   and collect_vars rev_yes rev_no = function
     | ([], _) :: _ -> assert false
     | [ ((ps, _) as cl) ] when List.for_all group_var ps && rev_yes <> [] ->
@@ -1231,17 +1223,18 @@ and split_no_or cls args def k =
           collect_vars (cl :: rev_yes) rev_no rem
         else
           collect_vars rev_yes (cl :: rev_no) rem
-    | [] -> (
+    | [] ->
         let yes = List.rev rev_yes and no = List.rev rev_no in
-        match no with
-        | [] -> precompile_var args yes def k
-        | _ ->
-            let { me = next; matrix; top_default = def }, nexts = split no in
-            let idef = next_raise_count () in
-            precompile_var args yes
-              (Default_environment.cons matrix idef def)
-              ((idef, next) :: nexts)
-      )
+        insert_split precompile_var yes no def k
+  and insert_split precompile yes no def k =
+    match no with
+    | [] -> precompile args yes def k
+    | _ ->
+        let { me = next; matrix; top_default = def }, nexts = split no in
+        let idef = next_raise_count () in
+        precompile args yes
+          (Default_environment.cons matrix idef def)
+          ((idef, next) :: nexts)
   in
   split cls
 

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1208,11 +1208,24 @@ and split_no_or cls args def k =
         (* This enables an extra division in some frequent cases:
                last row is made of variables only *)
         collect group_discr rev_yes (cl :: rev_no) []
-    | ((p :: _, _) as cl) :: rem ->
+    | ((p :: _, _) as cl) :: rem -> (
         if can_group group_discr p && safe_before cl rev_no then
           collect group_discr (cl :: rev_yes) rev_no rem
         else
-          collect group_discr rev_yes (cl :: rev_no) rem
+          (* If we can't group the current clause, we have on more decision to
+             make: do we want to try raising lower clauses, or do we want to
+             split now?
+             The decision is made based on the following heuristic: if the group
+             consists of extension constructors, it is unlikely that we are
+             going to raise anything, so we split now.
+             Otherwise, we try to raise lower clauses. *)
+          match group_discr.pat_desc with
+          | Tpat_construct (_, { cstr_tag = Cstr_extension _ }, _) ->
+              assert (rev_no = []);
+              let yes = List.rev rev_yes in
+              insert_split group_discr yes (cl :: rem) def k
+          | _ -> collect group_discr rev_yes (cl :: rev_no) rem
+      )
     | [] ->
         let yes = List.rev rev_yes and no = List.rev rev_no in
         insert_split group_discr yes no def k

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1213,20 +1213,12 @@ and split_no_or cls args def k =
         let yes = List.rev rev_yes and no = List.rev rev_no in
         match no with
         | [] -> precompile_normal args yes def k
-        | cl :: rem -> (
-            match yes with
-            | [] ->
-                (* Could not succeeed in raising up a constr matching up *)
-                collect_vars [ cl ] [] rem
-            | _ ->
-                let { me = next; matrix; top_default = def }, nexts =
-                  split no
-                in
-                let idef = next_raise_count () in
-                precompile_normal args yes
-                  (Default_environment.cons matrix idef def)
-                  ((idef, next) :: nexts)
-          )
+        | _ ->
+            let { me = next; matrix; top_default = def }, nexts = split no in
+            let idef = next_raise_count () in
+            precompile_normal args yes
+              (Default_environment.cons matrix idef def)
+              ((idef, next) :: nexts)
       )
   and collect_vars rev_yes rev_no = function
     | ([], _) :: _ -> assert false

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1196,7 +1196,13 @@ let rec split_or argo cls args def =
   do_split [] [] [] cls
 
 and split_no_or cls args def k =
-  let rec collect_group can_group rev_yes rev_no = function
+  let rec split cls =
+    let discr = what_is_cases cls in
+    if group_var discr then
+      collect_vars [] [] cls
+    else
+      collect_group (get_group discr) [] [] cls
+  and collect_group can_group rev_yes rev_no = function
     | ([], _) :: _ -> assert false
     | ((p :: _, _) as cl) :: rem ->
         if can_group p && safe_before cl rev_no then
@@ -1252,12 +1258,6 @@ and split_no_or cls args def k =
               (Default_environment.cons matrix idef def)
               ((idef, next) :: nexts)
       )
-  and split cls =
-    let discr = what_is_cases cls in
-    if group_var discr then
-      collect_vars [] [] cls
-    else
-      collect_group (get_group discr) [] [] cls
   in
   split cls
 

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1212,12 +1212,7 @@ and split_no_or cls args def k =
     | [] -> (
         let yes = List.rev rev_yes and no = List.rev rev_no in
         match no with
-        | [] ->
-            ( { me = Pm { cases = yes; args; default = def };
-                matrix = as_matrix yes;
-                top_default = def
-              },
-              k )
+        | [] -> precompile_normal args yes def k
         | cl :: rem -> (
             match yes with
             | [] ->
@@ -1228,12 +1223,9 @@ and split_no_or cls args def k =
                   split no
                 in
                 let idef = next_raise_count () in
-                let def = Default_environment.cons matrix idef def in
-                ( { me = Pm { cases = yes; args; default = def };
-                    matrix = as_matrix yes;
-                    top_default = def
-                  },
-                  (idef, next) :: nexts )
+                precompile_normal args yes
+                  (Default_environment.cons matrix idef def)
+                  ((idef, next) :: nexts)
           )
       )
   and collect_vars rev_yes rev_no = function
@@ -1260,6 +1252,13 @@ and split_no_or cls args def k =
       )
   in
   split cls
+
+and precompile_normal args cls default k =
+  ( { me = Pm { cases = cls; args; default };
+      matrix = as_matrix cls;
+      top_default = default
+    },
+    k )
 
 and precompile_var args cls def k =
   (* Strategy: pop the first column,

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -32,9 +32,9 @@
    -- simplifying pattern heads in the process --, so that we obtain an ordered
    list of pms.
    For every pm in this list, and any two patterns in its first column, either
-   the patterns have the same head, or they match disjoint sets of values. (In
-   particular, two extension constructors that may or may not be equal due to
-   hidden rebinding cannot occur in the same simple pm.)
+   the patterns have the same head, or their heads match disjoint sets of
+   values. (In particular, two extension constructors that may or may not be
+   equal due to hidden rebinding cannot occur in the same simple pm.)
 
        2. Compilation
        --------------
@@ -1199,6 +1199,19 @@ let rec split_or argo cls args def =
   do_split [] [] [] cls
 
 and split_no_or cls args def k =
+  (* We split the remaining clauses in as few pms as possible while maintaining
+     the property stated earlier (cf. {1. Precompilation}), i.e. for
+     any pm in the result, it is possible to decide for any two patterns
+     on the first column whether their heads are equal or not.
+
+     This generally means that we'll have two kinds of pms: ones where the first
+     column is made of variables only, and ones where the head is actually a
+     discriminating pattern.
+
+     There is some subtlety regarding the handling of extension constructors
+     (where it is not always possible to syntactically decide whether two
+     different heads match different values), but this is handled by the
+     [can_group] function. *)
   let rec split cls =
     let discr = what_is_first_case cls in
     collect discr [] [] cls

--- a/bytecomp/matching.ml
+++ b/bytecomp/matching.ml
@@ -1234,7 +1234,7 @@ and split_no_or cls args def k =
       if group_var group_discr then
         precompile_var
       else
-        precompile_normal
+        do_not_precompile
     in
     match no with
     | [] -> precompile_group args yes def k
@@ -1247,18 +1247,11 @@ and split_no_or cls args def k =
   in
   split cls
 
-and precompile_normal args cls default k =
-  ( { me = Pm { cases = cls; args; default };
-      matrix = as_matrix cls;
-      top_default = default
-    },
-    k )
-
 and precompile_var args cls def k =
   (* Strategy: pop the first column,
      precompile the rest, add a PmVar to all precompiled submatrices.
 
-     If the rest doesn't generate any split, abort and dont_precompile_var. *)
+     If the rest doesn't generate any split, abort and do_not_precompile. *)
   match args with
   | [] -> assert false
   | _ :: ((Lvar v, _) as arg) :: rargs -> (
@@ -1267,7 +1260,7 @@ and precompile_var args cls def k =
       match cls with
       | [ _ ] ->
           (* as split as it can *)
-          dont_precompile_var args cls def k
+          do_not_precompile args cls def k
       | _ -> (
           (* Precompile *)
           let var_cls =
@@ -1287,7 +1280,7 @@ and precompile_var args cls def k =
           match nexts with
           | [] ->
               (* If you need *)
-              dont_precompile_var args cls def k
+              do_not_precompile args cls def k
           | _ ->
               let rec rebuild_matrix pmh =
                 match pmh with
@@ -1327,9 +1320,9 @@ and precompile_var args cls def k =
               (rfirst, rnexts)
         )
     )
-  | _ -> dont_precompile_var args cls def k
+  | _ -> do_not_precompile args cls def k
 
-and dont_precompile_var args cls def k =
+and do_not_precompile args cls def k =
   ( { me = Pm { cases = cls; args; default = def };
       matrix = as_matrix cls;
       top_default = def


### PR DESCRIPTION
Aka: *No! **You** review*.

Remember the docstring at the top of the file that you so confidently approved:
```
  (split_and_precompile)                                                    
We first split the initial pattern matching (or "pm") along its first column
-- simplifying pattern heads in the process --, so that we obtain an ordered
list of pms.                                                                
For every pm in this list, and any two patterns in its first column, either 
the patterns have the same head, or they match disjoint sets of values. (In 
particular, two extension constructors that may or may not be equal due to  
hidden rebinding cannot occur in the same simple pm.)                       
```

We had some back and forth about the second paragraph of that one, and I think we are going to need to refine it further.
While I believe it is correct (the pms do satisfy this invariant), it is actually weaker than the post-condition provided by `split_and_precompile`, indeed its current wording currently allows the following to lines in the same pm:
- `(Ext_C1, true)` and `(Ext_C2, false)` even when `Ext_C1 ≟ Ext_C2`
- `(C1, true)` and `(_, false)`

The post-condition is actually:
```
∀pm, ∀row1 row2 in pm,
  kind(head(row1)) = kind(head(row2))
  && (head(row1) = head(row2) || head(row1) ≠ head(row2))
```
Note:
- until the addition of extensible types, the second part trivially held
- I will let you put that into words so that we can update the comment at the top of the file

If we look at `split_constr` and `split_naive`, they both make the assumption that there can be only two kinds of patterns on the first column: omegas, or discriminating patterns. Giving birth to the recursion scheme based on `split_ex / split_noex` (that we renamed to `collect_group / collect_var`).

I believe we can ignore that assumption, and produce a much simpler scheme: we have a single `collect` function, which goes through clauses in order; for each clause the **important** question is this: can we add it to the group/pm that we are currently producing? That is: does it very the condition stated above?
If yes, we add it to the group and we keep going, if not then there is a follow up *less important* question: do we split or do we try to look at the following rows and try to raise them? (It is less important because it does not affect correctness)
The heuristic used to answer is the one discussed will depend on the kind of the group being built (is its first column populated by extension constructors?).

I think the result is quite a lot simpler than before, hopefully you'll like it.