### PR TITLE
matching.ml: correct a missed optimization opportunity in split_no_or

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1028,6 +1028,14 @@ let is_or p =
   | Tpat_or _ -> true
   | _ -> false
 
+let rec heads_are_var p =
+  match p.pat_desc with
+  | Tpat_any | Tpat_var _ -> true
+  | Tpat_alias (p, _, _) -> heads_are_var p
+  | Tpat_or (p1, p2, _) ->
+      heads_are_var p1 && heads_are_var p2
+  | _ -> false
+
 let equiv_pat p q = le_pat p q && le_pat q p
 
 let rec extract_equiv_head p l =
@@ -1218,7 +1226,9 @@ and split_no_or cls args def k =
     collect discr [] [] cls
   and collect group_discr rev_yes rev_no = function
     | ([], _) :: _ -> assert false
-    | [ ((ps, _) as cl) ] when List.for_all group_var ps && rev_yes <> [] ->
+    | [ ((ps, _) as cl) ] when
+           rev_yes <> [] && List.for_all heads_are_var ps
+      ->
         (* This enables an extra division in some frequent cases:
                last row is made of variables only
            Cf the first part of testsuite/tests/basic/patmatch_split_no_or.ml *)

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -35,8 +35,9 @@ let last_is_vars = function
   (last_is_vars/16 =
      (function param/19 : int
        (catch
-         (if (field 0 param/19) (if (field 1 param/19) (exit 3) 1) (exit 3))
-        with (3) (if (field 1 param/19) 3 2))))
+         (if (field 0 param/19) (if (field 1 param/19) (exit 3) 1)
+           (if (field 1 param/19) (exit 3) 2))
+        with (3) 3)))
   (apply (field 1 (global Toploop!)) "last_is_vars" last_is_vars/16))
 val last_is_vars : bool * bool -> int = <fun>
 |}]
@@ -49,12 +50,12 @@ type t += A | B of unit | C of bool * int;;
 0a
 type t = ..
 (let
-  (A/22 = (makeblock 248 "A" (caml_fresh_oo_id 0))
-   B/23 = (makeblock 248 "B" (caml_fresh_oo_id 0))
-   C/24 = (makeblock 248 "C" (caml_fresh_oo_id 0)))
-  (seq (apply (field 1 (global Toploop!)) "A/22" A/22)
-    (apply (field 1 (global Toploop!)) "B/23" B/23)
-    (apply (field 1 (global Toploop!)) "C/24" C/24)))
+  (A/23 = (makeblock 248 "A" (caml_fresh_oo_id 0))
+   B/24 = (makeblock 248 "B" (caml_fresh_oo_id 0))
+   C/25 = (makeblock 248 "C" (caml_fresh_oo_id 0)))
+  (seq (apply (field 1 (global Toploop!)) "A/23" A/23)
+    (apply (field 1 (global Toploop!)) "B/24" B/24)
+    (apply (field 1 (global Toploop!)) "C/25" C/25)))
 type t += A | B of unit | C of bool * int
 |}]
 
@@ -68,20 +69,20 @@ let f = function
 ;;
 [%%expect{|
 (let
-  (C/24 = (apply (field 0 (global Toploop!)) "C/24")
-   B/23 = (apply (field 0 (global Toploop!)) "B/23")
-   A/22 = (apply (field 0 (global Toploop!)) "A/22")
-   f/25 =
-     (function param/26 : int
-       (let (*match*/27 =a (field 0 param/26))
+  (C/25 = (apply (field 0 (global Toploop!)) "C/25")
+   B/24 = (apply (field 0 (global Toploop!)) "B/24")
+   A/23 = (apply (field 0 (global Toploop!)) "A/23")
+   f/26 =
+     (function param/27 : int
+       (let (*match*/28 =a (field 0 param/27))
          (catch
-           (if (== *match*/27 A/22) (if (field 1 param/26) 1 (exit 8))
+           (if (== *match*/28 A/23) (if (field 1 param/27) 1 (exit 8))
              (exit 8))
           with (8)
-           (if (field 1 param/26)
-             (if (== (field 0 *match*/27) B/23) 2
-               (if (== (field 0 *match*/27) C/24) 3 4))
-             (if (field 2 param/26) 12 11))))))
-  (apply (field 1 (global Toploop!)) "f" f/25))
+           (if (field 1 param/27)
+             (if (== (field 0 *match*/28) B/24) 2
+               (if (== (field 0 *match*/28) C/25) 3 4))
+             (if (field 2 param/27) 12 11))))))
+  (apply (field 1 (global Toploop!)) "f" f/26))
 val f : t * bool * bool -> int = <fun>
 |}]


### PR DESCRIPTION
One optimization in split_no_or is the insertion of a split before
a last matrix line that has only variables. Splitting a matrix there
creates two default environments (instead of one for the non-split
matrix), the first of which often gets specialized away by further
refinement, and the second one jumping directly to the catch-all
case -- this produces better code.

The code would detect this case (all-variable last row) by calling
`group_var` on all the patterns of the row, but the `group_*`
functions assume that their input is already simplified, and only the
first column of the row is simplified.

The present commit fixes it by defining a predicates that iterates on
"all the simple heads" of a pattern -- in the case of or-patterns, we
collect the heads of both alternatives. In the future we will refactor
this code using Parmatch.Simple_head.t, and the function invocation
may change.

Note: two testcases are changed in tests/basic/patmatch_split_no_or,
the first is the actual optimization and the second is just
stamp-related noise.